### PR TITLE
Sidepenal Toggle button for User Navigation

### DIFF
--- a/qa-lang-misc.php
+++ b/qa-lang-misc.php
@@ -6,16 +6,33 @@ if (!defined('QA_VERSION')) { // don't allow this page to be requested directly 
 }
 
 return array(
-    'profile_not_visible' => 'Profile unavailable — this account does not yet meet the visibility criteria.',
-	'reorder_ask' => 'Reorder Ask form fields (Question Description → Question Title → Similar Questions.)',
-	'redirection_fav' => 'Display lists redirection link at the questions section in the favorites page.',
+	// Admin page - Section titles
+	'admin_section_title_general' => 'General:', // In case general options will be added later
+	'admin_section_title_sidepanel' => 'Sidepanel:',
+	'admin_section_title_profile' => 'Profile:',
+	'admin_section_title_other' => 'Other:',
+	
+	// Admin options
+	'opt_hide_sidepanel' => 'Add "Hide Sidepanel" toggle to the User Navigation.',
+	
 	'minimum_active_profile_visible' => 'Minimum active days before profile is viewable for public (zero - for no restriction)',
 	'minimum_active_profile_editable' => 'Minimum active days before user can edit their profile (zero - for no restriction)',
+	'opt_username_change' => 'Allowed number of username changes per user:',
+	'opt_username_change_description' => 'Set to 0 to disable username change completely.',
+	
+	'reorder_ask' => 'Reorder Ask form fields (Question Description → Question Title → Similar Questions.)',
+	'redirection_fav' => 'Display lists redirection link at the questions section in the favorites page.',
+	'print_enable' => 'Enable Print Button on Question/Blog',
+	'print_css' => 'Custom Print CSS',
+	'print_css_description' => 'Full print stylesheet. Modify to change layout, fonts, etc.',
+	
+	// Frontend descriptions
+	'profile_not_visible' => 'Profile unavailable — this account does not yet meet the visibility criteria.',
 	'profile_not_editable' => 'Your account isn’t mature enough to edit the profile yet.',
+	
 	'redirection_fav_content' => 'Click here to browse your favorite questions by category',
+	
 	'print_popup' => 'Print',
 	'print_label' => 'Print',
 	'note_heading' => 'Self Note:',
-	'print_enable' => 'Enable Print Button on Question/Blog',
-	'print_css' => 'Custom Print CSS',
 );

--- a/qa-misc-admin.php
+++ b/qa-misc-admin.php
@@ -7,19 +7,19 @@ if (!defined('QA_VERSION')) { // don't allow this page to be requested directly 
 
 class qa_misc_admin {
 
-    function option_default($option) {
-        switch ($option) {
-            case 'misc_tweaks_ask_reorder':
-            case 'add_list_link':
-                return 0;
-            case 'misc_min_active_days_profile_visible':
-            case 'misc_min_active_days_profile_editable':
-                return 0;
+	function option_default($option) {
+		switch ($option) {
+			case 'misc_tweaks_ask_reorder':
+			case 'add_list_link':
+				return 0;
+			case 'misc_min_active_days_profile_visible':
+			case 'misc_min_active_days_profile_editable':
+				return 0;
 			case 'allowed_username_changes':
-            case 'enable_print_button':
-                return 1; // enabled by default
-            case 'custom_print_css':
-                return <<<CSS
+			case 'enable_print_button':
+				return 1; // enabled by default
+			case 'custom_print_css':
+				return <<<CSS
 							body { background:#fff; color:#000; font-family:"Segoe UI", Arial, sans-serif; margin:30px; }
 							.print-container { max-width:900px; margin:auto; }
 							.print-meta { font-size:14px; color:#555; margin-bottom:20px; }
@@ -65,43 +65,56 @@ class qa_misc_admin {
 							}
 
 							CSS;
-        }
-    }
+		}
+	}
 
-    function admin_form(&$qa_content) {
+	function admin_form(&$qa_content) {
 
-        $saved = false;
+		$saved = false;
 		if (qa_clicked('reset_print_css')) {
 			qa_opt('custom_print_css', $this->option_default('custom_print_css'));
 			$saved = true;
 		}
-        if (qa_clicked('misc_tweaks_save')) {
-            qa_opt('misc_tweaks_ask_reorder', (int)qa_post_text('misc_tweaks_ask_reorder'));
+		if (qa_clicked('misc_tweaks_save')) {
+			qa_opt('misc_enable_hide_sidepanel', (int)qa_post_text('misc_enable_hide_sidepanel'));
+			qa_opt('misc_tweaks_ask_reorder', (int)qa_post_text('misc_tweaks_ask_reorder'));
 			qa_opt('add_list_link', (int)qa_post_text('add_list_link'));
 			qa_opt('misc_min_active_days_profile_visible', (int)qa_post_text('misc_min_active_days_profile_visible'));
 			qa_opt('misc_min_active_days_profile_editable', (int)qa_post_text('misc_min_active_days_profile_editable'));
-            qa_opt('enable_print_button', (int)qa_post_text('enable_print_button'));
-            qa_opt('custom_print_css', qa_post_text('custom_print_css'));
+			qa_opt('enable_print_button', (int)qa_post_text('enable_print_button'));
+			qa_opt('custom_print_css', qa_post_text('custom_print_css'));
 			qa_opt('allowed_username_changes', (int)qa_post_text('allowed_username_changes'));
-            $saved = true;
-        }
+			$saved = true;
+		}
+		
+		qa_set_display_rules($qa_content, array(
+			'custom_print_css' => 'enable_print_button',
+		));
 
-        return array(
-            'ok' => $saved ? 'Settings saved' : null,
+		return array(
+			'ok' => $saved ? 'Settings saved' : null,
 
-            'fields' => array(
-                array(
-                    'label' => qa_lang_html('qa_misc_lang/reorder_ask'),
-                    'type' => 'checkbox',
-                    'value' => qa_opt('misc_tweaks_ask_reorder'),
-                    'tags'  => 'name="misc_tweaks_ask_reorder"',
-                ),
+			'fields' => array(
+				// Sidepanel
 				array(
-                    'label' => qa_lang_html('qa_misc_lang/redirection_fav'),
-                    'type' => 'checkbox',
-                    'value' => qa_opt('add_list_link'),
-                    'tags'  => 'name="add_list_link"',
-                ),
+					'type' => 'custom',
+					'html' => '<strong>'.qa_lang('qa_misc_lang/admin_section_title_sidepanel').'</strong>',
+				),
+				array(
+					'label' => qa_lang_html('qa_misc_lang/opt_hide_sidepanel'),
+					'type' => 'checkbox',
+					'value' => qa_opt('misc_enable_hide_sidepanel'),
+					'tags'  => 'name="misc_enable_hide_sidepanel"',
+				),
+				array(
+					'type' => 'blank',
+				),
+				
+				// Profile
+				array(
+					'type' => 'custom',
+					'html' => '<strong>'.qa_lang('qa_misc_lang/admin_section_title_profile').'</strong>',
+				),
 				array(
 					'type'  => 'custom',
 					'html'  => '<label>'
@@ -117,38 +130,63 @@ class qa_misc_admin {
 						. '</label>',
 				),
 				array(
-                    'label' => qa_lang_html('qa_misc_lang/print_enable'),
-                    'type'  => 'checkbox',
-                    'value' => qa_opt('enable_print_button'),
-                    'tags'  => 'name="enable_print_button"',
-                ),
-                array(
-                    'label' => qa_lang_html('qa_misc_lang/print_css'),
-                    'type'  => 'textarea',
-                    'rows'  => 25,
-                    'value' => qa_opt('custom_print_css'),
-                    'tags'  => 'name="custom_print_css" style="width:100%; font-family:monospace;"',
-                    'note'  => 'Full print stylesheet. Modify to change layout, fonts, etc.',
-                ),
-				array(
-					'label' => 'Allowed number of username changes per user:',
+					'label' => qa_lang_html('qa_misc_lang/opt_username_change'),
 					'tags' => 'name="allowed_username_changes"',
 					'value' => qa_opt('allowed_username_changes'),
 					'type' => 'number',
-					'note' => 'Set to 0 to disable username change completely.',
+					'note' => qa_lang_html('qa_misc_lang/opt_username_change_description'),
 				),
-            ),
+				array(
+					'type' => 'blank',
+				),
+				
+				// Other
+				array(
+					'type' => 'custom',
+					'html' => '<strong>'.qa_lang('qa_misc_lang/admin_section_title_other').'</strong>',
+				),
+				array(
+					'label' => qa_lang_html('qa_misc_lang/reorder_ask'),
+					'type' => 'checkbox',
+					'value' => qa_opt('misc_tweaks_ask_reorder'),
+					'tags'  => 'name="misc_tweaks_ask_reorder"',
+				),
+				array(
+					'label' => qa_lang_html('qa_misc_lang/redirection_fav'),
+					'type' => 'checkbox',
+					'value' => qa_opt('add_list_link'),
+					'tags'  => 'name="add_list_link"',
+				),
+				array(
+					'label' => qa_lang_html('qa_misc_lang/print_enable'),
+					'type'  => 'checkbox',
+					'value' => qa_opt('enable_print_button'),
+					'tags'  => 'name="enable_print_button" ID="enable_print_button"',
+				),
+				array(
+					'id' => 'custom_print_css', // This will be a show/hide section, based on the previous checkbox's state
+					'label' => qa_lang_html('qa_misc_lang/print_css'),
+					'type'  => 'textarea',
+					'rows'  => 25,
+					'value' => qa_opt('custom_print_css'),
+					'tags'  => 'name="custom_print_css" style="width:100%; font-family:monospace;"',
+					'note' => qa_lang_html('qa_misc_lang/print_css_description'),
+				),
+				array(
+					'type' => 'blank',
+				),
+			),
 
-            'buttons' => array(
-                array(
-                    'label' => 'Save',
-                    'tags' => 'name="misc_tweaks_save"',
-                ),
+			'buttons' => array(
+				array(
+					'label' => 'Save',
+					'tags' => 'name="misc_tweaks_save"',
+				),
 				array(
 					'label' => 'Reset CSS to Default',
 					'tags' => 'name="reset_print_css" onclick="return confirm(\'Are you sure you want to reset the print CSS to default?\')"',
 				),
-            ),
-        );
-    }
+			),
+		);
+	}
 }

--- a/qa-plugin.php
+++ b/qa-plugin.php
@@ -5,37 +5,40 @@ if (!defined('QA_VERSION')) { // don't allow this page to be requested directly 
 	exit;
 }
 
-// register admin page
+// Register admin page
 qa_register_plugin_module('module', 'qa-misc-admin.php', 'qa_misc_admin', 'Misc Tweaks Settings');
 
-//register ask page layer
+// Register ask page layer
 qa_register_plugin_layer('qa-ask-reorder-layer.php', 'ASK page reorder Layer');
 
-//register user profile hide and edit page layer
+// Register user profile hide and edit page layer
 qa_register_plugin_layer('qa-user-profile-hide-layer.php', 'Hiding spam users profile from normal users, Restricting users for updating their own profiles');
 
-//register favorites page layer
+// Register favorites page layer
 qa_register_plugin_layer('qa-favorite-list-link-layer.php', 'Adding lists link to the title of questions division in the favorites page Layer');
 
+// Register User Navigation toggle layer
+qa_register_plugin_layer('qa-sidebar-toggle-layer.php', 'Add Hide sidepanel toggle to User Navigation');
 
-//register print page layer
+
+// Register print page layer
 qa_register_plugin_layer('qa-print-layer.php', 'Adding buttons to questions');
 
-//Registering print page
+// Register print page
 qa_register_plugin_module('page', 'qa-print.php', 'qa_print_page', 'Page for printing questions/blogs');
 
-//Registering a widget
+// Register a widget
 qa_register_plugin_module('widget', 'qa-sidebar-toggle-widget.php', 'qa_sidebar_toggle_widget', 'Sidebar Toggle Widget');
 
-//register account page layer for username change
+// Register account page layer for username change
 qa_register_plugin_layer('qa-username-change-layer.php', 'Username Change Layer');
 
-//Registering event for catching the username change event
+// Register event for catching the username change event
 qa_register_plugin_module('event', 'qa-username-change-event.php', 'qa_username_change_event', 'Username Change Event');
 
-//Registering filer module to show the errors on the account page.
+// Register filer module to show the errors on the account page.
 qa_register_plugin_module('filter','qa-username-filter.php','qa_username_filter','Username Change Filter');
 
-// register lang
+// Register lang
 qa_register_plugin_phrases('qa-lang-misc.php', 'qa_misc_lang');
 

--- a/qa-sidebar-toggle-layer.php
+++ b/qa-sidebar-toggle-layer.php
@@ -1,0 +1,227 @@
+<?php
+
+class qa_html_theme_layer extends qa_html_theme_base
+{
+	public function head_css()
+	{
+		qa_html_theme_base::head_css();
+
+		// Return if option disabled
+		if (!qa_opt('misc_enable_hide_sidepanel')) return;
+		
+		$styles = '
+			<style>
+				.qa-nav-user-hide-sidepanel .qa-nav-user-nolink {
+					display: flex;
+					padding: 1rem 0;
+				}
+				.qa-nav-user-hide-sidepanel .flex-item {
+					display: flex;
+					justify-content: flex-start;
+					align-items: center;
+					flex-wrap: nowrap;
+				}
+				.qa-nav-user-hide-sidepanel .flex-end-toggle {
+					justify-content: flex-end;
+					flex-grow: 1;
+					display: flex;
+				}
+				
+				.sp-toggle-container {
+					color: #ebebeb;
+					position: relative;
+					width: 36px;
+					height: 14px;
+					margin: 4px 1px;
+					cursor: pointer;
+				}
+				.sp-toggle-wrapper {
+					position: absolute;
+					-webkit-overflow-scrolling: touch;
+					height: 100%;
+					width: 100%;
+					border-radius: 8px;
+					pointer-events: none;
+					opacity: 0.4;
+					transition: background-color linear .08s;
+					background-color: #929292;
+				}
+				[data-theme="dark"] .sp-toggle-wrapper {
+					background-color: #ebebeb;
+				}
+
+				.sp-toggle-button {
+					position: absolute;
+					top: -3px;
+					left: 0;
+					right: auto;
+					-webkit-overflow-scrolling: touch;
+					transition: transform linear .08s, background-color linear .08s;
+					will-change: transform;
+					height: 20px;
+					width: 20px;
+					border-radius: 50%;
+					box-shadow: 0 1px 5px 0 rgba(0, 0, 0, 0.6);
+					background-color: rgb(95, 99, 104);
+					cursor: pointer;
+				}
+				.toggle-active .sp-toggle-button, .toggle-active[checked] .sp-toggle-button {
+					transform: translateX(16px) translateZ(0);
+					background-color: #3ea6ff;
+				}
+				.qa-sidepanel.display-none {
+					display: none;
+				}
+				@media (max-width:575px) {
+					.qa-nav-user-hide-sidepanel {
+						display: none;
+					}
+				}
+			</style>
+		';
+		
+		if (qa_opt('site_theme') == 'Polaris' && method_exists($this, 'minify_code')) {
+			$this->output($this->minify_code($styles));
+		} else {
+			$this->output($styles);
+		}
+	}
+	
+	public function prepend_toggle_user_nav()
+	{
+		// Append it to the User Nav
+		if (
+			qa_is_logged_in() &&
+			isset($this->content['navigation']['user'])
+		) {
+			// Only add 'hide-sidepanel' if the 'profile' link exists in the user nav - (POLARIS THEME)
+			if (isset($this->content['navigation']['user']['profile'])) {
+				// Get the 'user' navigation array
+				$userNav = $this->content['navigation']['user'];
+
+				// Split the array before and after 'profile'
+				$beforeProfile = array_slice($userNav, 0, array_search('profile', array_keys($userNav)) + 0);
+				$afterProfile = array_slice($userNav, array_search('profile', array_keys($userNav)) + 0);
+
+				// Add 'hide-sidepanel' before 'profile'
+				$this->content['navigation']['user'] = array_merge(
+					$beforeProfile,
+					['hide-sidepanel' => [
+						'label' => '
+							<div class="flex-item">Hide Sidepanel</div>
+							<div class="flex-end-toggle">
+								<div class="sp-toggle-container sidepanel-trigger">
+									<div class="sp-toggle-wrapper"></div>
+									<div class="sp-toggle-button"></div>
+								</div>
+							</div>
+							<div class="mf-divider"></div>
+						',
+					]],
+					$afterProfile
+				);
+			} else {
+				// Other themes
+				
+				// Get the 'user' navigation array
+				$userNav = $this->content['navigation']['user'];
+
+				// Split the array before and after 'updates'
+				$beforeProfile = array_slice($userNav, 0, array_search('updates', array_keys($userNav)) + 0);
+				$afterProfile = array_slice($userNav, array_search('updates', array_keys($userNav)) + 0);
+
+				// Add 'hide-sidepanel' before 'updates'
+				$this->content['navigation']['user'] = array_merge(
+					$beforeProfile,
+					['hide-sidepanel' => [
+						'label' => '
+							<div class="no-select flex-item">Hide Sidepanel</div>
+							<div class="flex-end-toggle">
+								<div class="sp-toggle-container sidepanel-trigger">
+									<div class="sp-toggle-wrapper"></div>
+									<div class="sp-toggle-button"></div>
+								</div>
+							</div>
+							<div class="mf-divider"></div>
+						',
+					]],
+					$afterProfile
+				);
+			}
+		}
+	}
+	
+	function doctype()
+	{
+		parent::doctype();
+		
+		if (!qa_opt('misc_enable_hide_sidepanel')) return;
+		
+		// Add sidebar toggle to User Navigation
+		$this->prepend_toggle_user_nav();
+	}
+	
+	public function body_hidden()
+	{
+		qa_html_theme_base::body_hidden();
+		// $patchNumber = self::PATCH_NUMBER;
+		
+		// Return if option disabled
+		if (!qa_opt('misc_enable_hide_sidepanel')) return;
+		
+		$javascript = '
+		<script>
+			(() => {
+				// Sidepanel elements
+				const sidepanelTrigger = document.querySelector(".sidepanel-trigger");
+				const sidepanel = document.querySelector(".qa-sidepanel");
+				
+				// Exit if required elements are missing
+				if (!sidepanel || !sidepanelTrigger) {
+					return;
+				}
+				
+				// Get stored option (default: false)
+				const getSidebarHidden = () => {
+					return localStorage.getItem("stw-sidebar-hidden") === "true";
+				};
+
+				// Save option
+				const setSidebarHidden = (isHidden) => {
+					localStorage.setItem("stw-sidebar-hidden", String(isHidden));
+				};
+
+				// Apply UI state
+				const applySidebarState = (isHidden) => {
+					sidepanel.classList.toggle("display-none", isHidden);
+					sidepanelTrigger.classList.toggle("toggle-active", isHidden);
+				};
+
+				// Toggle handler
+				const toggleSidepanel = () => {
+					const isHidden = getSidebarHidden();
+					const newState = !isHidden;
+
+					setSidebarHidden(newState);
+					applySidebarState(newState);
+				};
+
+				// Initial state on page load
+				const initialSidebarHidden = getSidebarHidden();
+				applySidebarState(initialSidebarHidden);
+
+				// Click listener
+				sidepanelTrigger.addEventListener("click", () => {
+					toggleSidepanel();
+				});
+			})();
+		</script>';
+		
+		if (qa_opt('site_theme') == 'Polaris' && method_exists($this, 'minify_code')) {
+			$this->output($this->minify_code($javascript));
+		} else {
+			$this->output($javascript);
+		}
+	}
+	
+}

--- a/qa-sidebar-toggle-widget.php
+++ b/qa-sidebar-toggle-widget.php
@@ -14,6 +14,10 @@ class qa_sidebar_toggle_widget
 
     public function output_widget($region, $place, $themeobject, $template, $request, $qa_content)
     {
+        // If "Hide sidepanel" toggle already enabled for User Navigation in Plugin Options -> return
+        // No point in outputting 2 buttons that do the same.
+        if (qa_opt('misc_enable_hide_sidepanel')) return;
+        
         $themeobject->output('
             <div id="stw-widget-wrap">
                 <button id="stw-hide-btn" class="stw-btn" type="button">


### PR DESCRIPTION
- Added Sidepanel Toggle button to the User Navigation.
- Created an option to activate/deactivate it on Plugin Options.
- Created rule to prevent the sidebar widget to display a second toggle button as well. As this would be pointless.
- Reorganized Admin settings, and language file.
- Added new and missing language entries to the `qa-lang-misc.php` file.
- In the plugin options, when you enable/disable the print button now it hides or shows the "Custom Print CSS" depending on the checkbox's current state.